### PR TITLE
fix for mysql2 parameter notation

### DIFF
--- a/source/FoxHound.js
+++ b/source/FoxHound.js
@@ -412,6 +412,9 @@ var FoxHound = function()
 			var tmpConnector = (typeof(pConnector) === 'undefined') ? 'AND' : pConnector;
 			var tmpParameter = (typeof(pParameter) === 'undefined') ? pColumn : pParameter;
 
+			//support table.field notation (mysql2 requires this)
+			tmpParameter = tmpParameter.replace('.', '_');
+
 			var tmpFilter = (
 				{
 					Column: pColumn,


### PR DESCRIPTION
Parameter names fallback to field names with addFilter(), in which case Table.Field will be a notation which is unsupported by mysql2. This fixes it.